### PR TITLE
Propagate download errors

### DIFF
--- a/internal/downloader/dl_test.go
+++ b/internal/downloader/dl_test.go
@@ -22,7 +22,10 @@ func TestGetPages(t *testing.T) {
 	}
 	cbz := zip.NewWriter(file)
 	defer cbz.Close()
-	cc := downloader.NewDownload(ctx, "26964", "718179")
+	cc, err := downloader.NewDownload(ctx, "26964", "718179")
+	if err != nil {
+		t.Fatal(err)
+	}
 	for n := range cc.Pages {
 		log.Printf("Downloading page %d\n", n)
 		w, err := cbz.Create(fmt.Sprintf("%d.jpg", n))


### PR DESCRIPTION
## Summary
- return errors from downloader initialization and page retrieval
- update MCP download helpers to check initialization errors

## Testing
- `go test ./...` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68980957a8d08322bcd60da1bb7684f5