### PR TITLE
feat: add concurrent page downloading

### DIFF
--- a/internal/downloader/dl_test.go
+++ b/internal/downloader/dl_test.go
@@ -22,7 +22,10 @@ func TestGetPages(t *testing.T) {
 	}
 	cbz := zip.NewWriter(file)
 	defer cbz.Close()
-	cc := downloader.NewDownload(ctx, "26964", "718179")
+	cc, err := downloader.NewDownload(ctx, "26964", "718179")
+	if err != nil {
+		t.Fatal(err)
+	}
 	for n := range cc.Pages {
 		log.Printf("Downloading page %d\n", n)
 		w, err := cbz.Create(fmt.Sprintf("%d.jpg", n))

--- a/internal/epub/epub_test.go
+++ b/internal/epub/epub_test.go
@@ -8,15 +8,15 @@ import (
 	"testing"
 )
 
-// Test that EPUBWriter writes image filenames correctly in the manifest
-func TestEPUBWriterManifestUsesFilenames(t *testing.T) {
+// Test that EPUBWriter records filenames and MIME types correctly in the manifest
+func TestEPUBWriterManifestRecordsMimeTypes(t *testing.T) {
 	var buf bytes.Buffer
 	writer := NewEPUBWriter(&buf, "Test Title")
 
 	if err := writer.AddPage("img1.png", []byte("data1")); err != nil {
 		t.Fatalf("AddPage img1 failed: %v", err)
 	}
-	if err := writer.AddPage("img2.png", []byte("data2")); err != nil {
+	if err := writer.AddPage("img2.jpg", []byte("data2")); err != nil {
 		t.Fatalf("AddPage img2 failed: %v", err)
 	}
 
@@ -50,10 +50,10 @@ func TestEPUBWriterManifestUsesFilenames(t *testing.T) {
 		t.Fatalf("content.opf not found in EPUB")
 	}
 
-	if !strings.Contains(contentOpf, "href=\"images/img1.png\"") {
-		t.Errorf("manifest missing img1.png: %s", contentOpf)
+	if !strings.Contains(contentOpf, "href=\"images/img1.png\" media-type=\"image/png\"") {
+		t.Errorf("manifest missing img1.png with image/png: %s", contentOpf)
 	}
-	if !strings.Contains(contentOpf, "href=\"images/img2.png\"") {
-		t.Errorf("manifest missing img2.png: %s", contentOpf)
+	if !strings.Contains(contentOpf, "href=\"images/img2.jpg\" media-type=\"image/jpeg\"") {
+		t.Errorf("manifest missing img2.jpg with image/jpeg: %s", contentOpf)
 	}
 }


### PR DESCRIPTION
## Summary
- refactor CBZ/EPUB downloads to use worker goroutines
- limit concurrency via COMICSD_WORKERS env var and aggregate errors
- log worker progress during downloads

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689809673d1c83228b621a6b121b05cd