### PR TITLE
Propagate chromedp errors and surface to users

### DIFF
--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/chromedp/chromedp"
+	"go.uber.org/multierr"
 )
 
 type ComicInfo struct {
@@ -39,9 +40,91 @@ func NewComicInfoFetcher(ctx context.Context) *ComicInfoFetcher {
 	return &ComicInfoFetcher{ctx: ctx}
 }
 
+// textContent extracts text content using chromedp. Defined as a variable for tests.
+var textContent = func(ctx context.Context, sel string, res *string) error {
+	return chromedp.Text(sel, res, chromedp.ByQuery).Do(ctx)
+}
+
+// evalJS evaluates JavaScript using chromedp. Defined as a variable for tests.
+var evalJS = func(ctx context.Context, expr string, res interface{}) error {
+	return chromedp.Evaluate(expr, res).Do(ctx)
+}
+
+// fillComicInfo fills the ComicInfo struct by scraping the page.
+func (c *ComicInfoFetcher) fillComicInfo(info *ComicInfo) chromedp.ActionFunc {
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		var err error
+
+		// Get comic title
+		var title string
+		if e := textContent(ctx, `.book-title h1`, &title); e != nil {
+			err = multierr.Append(err, fmt.Errorf("get title: %w", e))
+		} else {
+			info.Title = strings.TrimSpace(title)
+		}
+
+		// Get author and status from detail list
+		var detailText string
+		if e := textContent(ctx, `.book-detail .detail-list`, &detailText); e != nil {
+			err = multierr.Append(err, fmt.Errorf("get detail: %w", e))
+		} else {
+			if strings.Contains(detailText, "作者") || strings.Contains(detailText, "漫畫作者") {
+				re := regexp.MustCompile(`作者[：:]\s*([^\n\r]+)`)
+				matches := re.FindStringSubmatch(detailText)
+				if len(matches) > 1 {
+					info.Author = strings.TrimSpace(matches[1])
+				}
+			}
+			if strings.Contains(detailText, "狀態") || strings.Contains(detailText, "状态") {
+				re := regexp.MustCompile(`狀態[：:]\s*([^\n\r]+)`)
+				matches := re.FindStringSubmatch(detailText)
+				if len(matches) > 1 {
+					info.Status = strings.TrimSpace(matches[1])
+				}
+			}
+		}
+
+		// Get description
+		var description string
+		if e := textContent(ctx, `#intro-all`, &description); e != nil {
+			err = multierr.Append(err, fmt.Errorf("get description: %w", e))
+		} else {
+			info.Description = strings.TrimSpace(description)
+		}
+
+		// Get chapters - use evaluate to get href attributes and titles
+		var chapterData []map[string]string
+		if e := evalJS(ctx, `Array.from(document.querySelectorAll('.chapter-list li a')).map(link => ({href: link.getAttribute('href'), title: link.textContent.trim(),}))`, &chapterData); e != nil {
+			err = multierr.Append(err, fmt.Errorf("get chapters: %w", e))
+		} else {
+			for _, data := range chapterData {
+				link := data["href"]
+				title := data["title"]
+
+				// Extract chapter ID from URL
+				re := regexp.MustCompile(`/comic/\d+/(\d+)\.html`)
+				matches := re.FindStringSubmatch(link)
+				chapterID := ""
+				if len(matches) > 1 {
+					chapterID = matches[1]
+				}
+
+				chapter := Chapter{
+					ID:    chapterID,
+					Title: title,
+					URL:   link,
+				}
+				info.Chapters = append(info.Chapters, chapter)
+			}
+		}
+
+		return err
+	})
+}
+
 func (c *ComicInfoFetcher) GetComicInfo(comicID string) (*ComicInfo, error) {
 	comicURL := fmt.Sprintf("https://tw.manhuagui.com/comic/%s/", comicID)
-	
+
 	info := &ComicInfo{
 		ID:       comicID,
 		Chapters: make([]Chapter, 0),
@@ -50,69 +133,7 @@ func (c *ComicInfoFetcher) GetComicInfo(comicID string) (*ComicInfo, error) {
 	err := chromedp.Run(c.ctx,
 		chromedp.Navigate(comicURL),
 		chromedp.WaitVisible(`.book-title`),
-		chromedp.ActionFunc(func(ctx context.Context) error {
-			// Get comic title
-			var title string
-			if err := chromedp.Text(`.book-title h1`, &title, chromedp.ByQuery).Do(ctx); err == nil {
-				info.Title = strings.TrimSpace(title)
-			}
-
-			// Get author and status from detail list
-			var detailText string
-			if err := chromedp.Text(`.book-detail .detail-list`, &detailText, chromedp.ByQuery).Do(ctx); err == nil {
-				if strings.Contains(detailText, "作者") || strings.Contains(detailText, "漫畫作者") {
-					re := regexp.MustCompile(`作者[：:]\s*([^\n\r]+)`)
-					matches := re.FindStringSubmatch(detailText)
-					if len(matches) > 1 {
-						info.Author = strings.TrimSpace(matches[1])
-					}
-				}
-				if strings.Contains(detailText, "狀態") || strings.Contains(detailText, "状态") {
-					re := regexp.MustCompile(`狀態[：:]\s*([^\n\r]+)`)
-					matches := re.FindStringSubmatch(detailText)
-					if len(matches) > 1 {
-						info.Status = strings.TrimSpace(matches[1])
-					}
-				}
-			}
-
-			// Get description
-			var description string
-			if err := chromedp.Text(`#intro-all`, &description, chromedp.ByQuery).Do(ctx); err == nil {
-				info.Description = strings.TrimSpace(description)
-			}
-
-			// Get chapters - use evaluate to get href attributes and titles
-			var chapterData []map[string]string
-			if err := chromedp.Evaluate(`
-				Array.from(document.querySelectorAll('.chapter-list li a')).map(link => ({
-					href: link.getAttribute('href'),
-					title: link.textContent.trim()
-				}))
-			`, &chapterData).Do(ctx); err == nil {
-				for _, data := range chapterData {
-					link := data["href"]
-					title := data["title"]
-					
-					// Extract chapter ID from URL
-					re := regexp.MustCompile(`/comic/\d+/(\d+)\.html`)
-					matches := re.FindStringSubmatch(link)
-					chapterID := ""
-					if len(matches) > 1 {
-						chapterID = matches[1]
-					}
-					
-					chapter := Chapter{
-						ID:    chapterID,
-						Title: title,
-						URL:   link,
-					}
-					info.Chapters = append(info.Chapters, chapter)
-				}
-			}
-
-			return nil
-		}),
+		c.fillComicInfo(info),
 	)
 
 	if err != nil {
@@ -132,7 +153,7 @@ func (info *ComicInfo) ToJSON() (string, error) {
 
 func (info *ComicInfo) ToPlainText() string {
 	var sb strings.Builder
-	
+
 	sb.WriteString(fmt.Sprintf("Comic ID: %s\n", info.ID))
 	sb.WriteString(fmt.Sprintf("Title: %s\n", info.Title))
 	if info.Author != "" {
@@ -146,61 +167,64 @@ func (info *ComicInfo) ToPlainText() string {
 	}
 	sb.WriteString(fmt.Sprintf("Chapters: %d\n", len(info.Chapters)))
 	sb.WriteString("\nChapter List:\n")
-	
+
 	for i, chapter := range info.Chapters {
 		sb.WriteString(fmt.Sprintf("  %d. [%s] %s\n", i+1, chapter.ID, chapter.Title))
 	}
-	
+
 	return sb.String()
 }
 
 func (c *ComicInfoFetcher) SearchComics(keyword string) ([]SearchResult, error) {
 	searchURL := fmt.Sprintf("https://tw.manhuagui.com/s/%s.html", keyword)
-	
+
 	var results []SearchResult
-	
+
 	err := chromedp.Run(c.ctx,
 		chromedp.Navigate(searchURL),
 		chromedp.WaitVisible(`.book-result`),
-		chromedp.ActionFunc(func(ctx context.Context) error {
-			// Get search results
-			var searchData []map[string]string
-			if err := chromedp.Evaluate(`
-				Array.from(document.querySelectorAll('.book-result .book-detail dt a')).map(link => ({
-					href: link.getAttribute('href'),
-					title: link.textContent.trim()
-				}))
-			`, &searchData).Do(ctx); err == nil {
-				for _, data := range searchData {
-					link := data["href"]
-					title := data["title"]
-					
-					// Extract comic ID from URL
-					re := regexp.MustCompile(`/comic/(\d+)/`)
-					matches := re.FindStringSubmatch(link)
-					comicID := ""
-					if len(matches) > 1 {
-						comicID = matches[1]
-					}
-					
-					if comicID != "" {
-						result := SearchResult{
-							ID:    comicID,
-							Title: title,
-							URL:   link,
-						}
-						results = append(results, result)
-					}
-				}
-			}
-			
-			return nil
-		}),
+		c.fillSearchResults(&results),
 	)
-	
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to search comics: %w", err)
 	}
-	
+
 	return results, nil
+}
+
+// fillSearchResults fills the search results slice by scraping the page.
+func (c *ComicInfoFetcher) fillSearchResults(results *[]SearchResult) chromedp.ActionFunc {
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		var err error
+
+		var searchData []map[string]string
+		if e := evalJS(ctx, `Array.from(document.querySelectorAll('.book-result .book-detail dt a')).map(link => ({href: link.getAttribute('href'), title: link.textContent.trim(),}))`, &searchData); e != nil {
+			err = multierr.Append(err, fmt.Errorf("get search results: %w", e))
+		} else {
+			for _, data := range searchData {
+				link := data["href"]
+				title := data["title"]
+
+				// Extract comic ID from URL
+				re := regexp.MustCompile(`/comic/(\d+)/`)
+				matches := re.FindStringSubmatch(link)
+				comicID := ""
+				if len(matches) > 1 {
+					comicID = matches[1]
+				}
+
+				if comicID != "" {
+					result := SearchResult{
+						ID:    comicID,
+						Title: title,
+						URL:   link,
+					}
+					*results = append(*results, result)
+				}
+			}
+		}
+
+		return err
+	})
 }

--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -1,0 +1,58 @@
+package info
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFillComicInfoMissingElements(t *testing.T) {
+	origText := textContent
+	origEval := evalJS
+	defer func() { textContent = origText; evalJS = origEval }()
+
+	textErrors := map[string]error{
+		`.book-title h1`:            errors.New("title missing"),
+		`.book-detail .detail-list`: errors.New("detail missing"),
+	}
+	textContent = func(ctx context.Context, sel string, res *string) error {
+		if err, ok := textErrors[sel]; ok {
+			return err
+		}
+		return nil
+	}
+	evalJS = func(ctx context.Context, expr string, res interface{}) error {
+		return errors.New("chapter missing")
+	}
+
+	info := &ComicInfo{ID: "1"}
+	fetcher := &ComicInfoFetcher{}
+	err := fetcher.fillComicInfo(info).Do(context.Background())
+	if err == nil {
+		t.Fatalf("expected error but got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "title missing") || !strings.Contains(msg, "detail missing") || !strings.Contains(msg, "chapter missing") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFillSearchResultsMissingElements(t *testing.T) {
+	origEval := evalJS
+	defer func() { evalJS = origEval }()
+
+	evalJS = func(ctx context.Context, expr string, res interface{}) error {
+		return errors.New("search missing")
+	}
+
+	var results []SearchResult
+	fetcher := &ComicInfoFetcher{}
+	err := fetcher.fillSearchResults(&results).Do(context.Background())
+	if err == nil {
+		t.Fatalf("expected error but got nil")
+	}
+	if !strings.Contains(err.Error(), "search missing") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -97,6 +97,7 @@ func (m *MCPServer) searchComics(args SearchComicsArgs) (*mcp_golang.ToolRespons
 	fetcher := info.NewComicInfoFetcher(ctx)
 	results, err := fetcher.SearchComics(args.Keyword)
 	if err != nil {
+		log.Printf("search comics error: %v", err)
 		return nil, fmt.Errorf("failed to search comics: %w", err)
 	}
 
@@ -128,6 +129,7 @@ func (m *MCPServer) getComicInfo(args GetComicInfoArgs) (*mcp_golang.ToolRespons
 	fetcher := info.NewComicInfoFetcher(ctx)
 	comicInfo, err := fetcher.GetComicInfo(args.ComicID)
 	if err != nil {
+		log.Printf("get comic info error: %v", err)
 		return nil, fmt.Errorf("failed to get comic info: %w", err)
 	}
 

--- a/internal/mcp/server_official.go
+++ b/internal/mcp/server_official.go
@@ -105,6 +105,7 @@ func searchComicsOfficial(ctx context.Context, cc *mcp.ServerSession, params *mc
 	fetcher := info.NewComicInfoFetcher(chromectx)
 	results, err := fetcher.SearchComics(params.Arguments.Keyword)
 	if err != nil {
+		log.Printf("search comics error: %v", err)
 		return nil, fmt.Errorf("failed to search comics: %w", err)
 	}
 
@@ -129,6 +130,7 @@ func getComicInfoOfficial(ctx context.Context, cc *mcp.ServerSession, params *mc
 	fetcher := info.NewComicInfoFetcher(chromectx)
 	comicInfo, err := fetcher.GetComicInfo(params.Arguments.ComicID)
 	if err != nil {
+		log.Printf("get comic info error: %v", err)
 		return nil, fmt.Errorf("failed to get comic info: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- capture and accumulate chromedp.Text and Evaluate errors when scraping comic info or search results
- bubble scraping errors up to MCP callers with log messages
- add tests simulating missing DOM elements to ensure error propagation

## Testing
- `go test ./...` *(fails: page load error net::ERR_TUNNEL_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6898146735448322bf807e0e1d8b4517